### PR TITLE
Correcting incorrect domain information

### DIFF
--- a/folder/projects/Course Project/Bulletin board service/Fastcampus-board-service-project/src/main/java/com/fastcampus/boardproject/domain/UserAccount.java
+++ b/folder/projects/Course Project/Bulletin board service/Fastcampus-board-service-project/src/main/java/com/fastcampus/boardproject/domain/UserAccount.java
@@ -9,7 +9,7 @@ import java.util.Objects;
 @ToString
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(indexes = {
-        @Index(columnList = "userId"),
+        @Index(columnList = "userId", unique = true),
         @Index(columnList = "email", unique = true),
         @Index(columnList = "createdAt"),
         @Index(columnList = "createdBy"),


### PR DESCRIPTION
It logs in with a member ID and identifies the user, so it should be identified UK for the key. I found that this was not reflected in the design.

This closes #44